### PR TITLE
feat(musicplayer): added repeat feature

### DIFF
--- a/src/components/MusicPlayer.tsx
+++ b/src/components/MusicPlayer.tsx
@@ -43,15 +43,24 @@ export const MusicPlayer: React.FC<IMusicPlayerProps> = (props) => {
         url={`https://youtu.be/${playingState.currentSong}`}
         playing
         controls
+        loop={
+          playingState.repeatPlaylist &&
+          playingState.shufflePlaylist.length === 1
+        }
         onEnded={(): void => {
           if (player.current !== null) {
-            if (!playingState.shufflePlaylist.length) {
-              player.current.seekTo(0);
+            let newVal;
+            if (
+              playingState.repeatPlaylist &&
+              playingState.currentPlaylistSong ===
+                playingState.shufflePlaylist.length - 1
+            ) {
               ReactGA.event({
                 category: 'Video',
                 action: 'Loop Embedded Video',
                 label: playingState.currentSong,
               });
+              newVal = 0;
             } else {
               ReactGA.event({
                 category: 'Video',
@@ -63,9 +72,9 @@ export const MusicPlayer: React.FC<IMusicPlayerProps> = (props) => {
                 playingState.shufflePlaylist.length - 1
               )
                 return;
-              const newVal = playingState.currentPlaylistSong + 1;
-              setCurrentPlaylistSong(newVal);
+              newVal = playingState.currentPlaylistSong + 1;
             }
+            setCurrentPlaylistSong(newVal);
           }
         }}
       />

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -19,6 +19,7 @@ export interface IPlayingState {
   currentSong: string | undefined;
   shufflePlaylist: IMusicRecordGrid[];
   currentPlaylistSong: number;
+  repeatPlaylist: boolean;
 }
 
 export interface ILocateSong {
@@ -28,10 +29,12 @@ export interface ILocateSong {
 const HomePage: React.FC = () => {
   const [filterText, setFilterText] = useState<string>();
   const [gridFiltered, setGridFiltered] = useState<boolean>(false);
+  const [playlistRepeat, setPlaylistRepeat] = useState<boolean>(false);
   const [playingState, setPlayingState] = useState<IPlayingState>({
     currentSong: undefined,
     shufflePlaylist: [],
     currentPlaylistSong: -1,
+    repeatPlaylist: false,
   });
   const shufflePlaylistPool = useRef<IMusicRecordGrid[]>([]);
   const [locateSong, setLocateSong] = useState<ILocateSong | undefined>();
@@ -52,11 +55,23 @@ const HomePage: React.FC = () => {
     }
   };
 
+  const onRepeatPlaylist: () => void = () => {
+    const newPlaylistRepeatVal = !playlistRepeat;
+    setPlaylistRepeat(newPlaylistRepeatVal);
+    setPlayingState((state) => {
+      return {
+        ...state,
+        repeatPlaylist: newPlaylistRepeatVal,
+      };
+    });
+  };
+
   const onGridSongChange: (song: string) => void = (song) => {
     setPlayingState({
       currentSong: song,
       shufflePlaylist: [],
       currentPlaylistSong: -1,
+      repeatPlaylist: playlistRepeat,
     });
   };
 
@@ -77,6 +92,7 @@ const HomePage: React.FC = () => {
       currentSong: shuffledSongs[0].youtube,
       shufflePlaylist: shuffledSongs,
       currentPlaylistSong: 0,
+      repeatPlaylist: playlistRepeat,
     });
     ReactGA.event({
       category: 'Playlist',
@@ -137,6 +153,35 @@ const HomePage: React.FC = () => {
             onChange={onFilterTextChanged}
             onKeyPress={onFilterTextKeyPress}
           />
+          <OverlayTrigger
+            delay={{ show: 250, hide: 100 }}
+            overlay={
+              <Tooltip id={`tooltip-start-playlist`}>
+                {playlistRepeat
+                  ? gridFiltered
+                    ? `Turn off repeat for Playlist (Filtered)`
+                    : `Turn off repeat for Playlist`
+                  : gridFiltered
+                  ? `Turn on repeat for Playlist (Filtered)`
+                  : `Turn on repeat for Playlist`}
+              </Tooltip>
+            }
+          >
+            <Button
+              variant={
+                playlistRepeat
+                  ? gridFiltered
+                    ? 'warning'
+                    : 'success'
+                  : gridFiltered
+                  ? 'outline-warning'
+                  : 'outline-success'
+              }
+              onClick={onRepeatPlaylist}
+            >
+              <i className="fa fa-repeat"></i>
+            </Button>
+          </OverlayTrigger>
           <OverlayTrigger
             delay={{ show: 250, hide: 100 }}
             overlay={


### PR DESCRIPTION
Hi @nanochromatic! I happened to stumble across your wonderful repository while listening to some MapleStory bgm on Youtube and I think it's a great project.  

As there was a lack of a 'replay' feature I thought it'd be great to have one -- so I forked your repo and created a branch for a repeat feature.  

This feature adds:  
- Full/filtered playlist to loop through from start of playlist if repeat button is toggled
- Loop logic for playlist to loop even if the filtered playlist only contains 1 song when repeat button is toggled  

I have added screenshots on how the UI looks like below:
| Playlist | Off | On |
| --- | --- | --- |
| Full | ![full_off](https://user-images.githubusercontent.com/59083326/211597041-36f3b8d7-851c-431e-ad36-16deb2be6af9.png) | ![full_on](https://user-images.githubusercontent.com/59083326/211597129-815eb2cf-a055-4f74-b95b-a404cb9628f8.png) |
| Filtered | ![filtered_off](https://user-images.githubusercontent.com/59083326/211597402-b9a6ed3a-9e3f-4957-8daf-cd332cbc12e0.png) | ![filtered_on](https://user-images.githubusercontent.com/59083326/211597256-64435a65-44e8-458d-9d13-b675c728798c.png) |

If this feature is something that is considered viable for you, please feel free to merge it; or if further clean-up for the code is required to fit the overall coding convention, do let me know too!